### PR TITLE
update GitHub alt project url

### DIFF
--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -18,7 +18,7 @@
             "cover": "github",
             "title": "GitHub Alt",
             "description": "NextJS, Firebase, Tailwind",
-            "url": "https://githubbyme.netlify.app/",
+            "url": "https://gitalt.netlify.app/",
             "code": "https://github.com/hemantwasthere/GitHub-Clone"
         },
         {


### PR DESCRIPTION
The previous link of GitHub alt was not working so I changed it to the new one mentioned in the project repository.